### PR TITLE
Could com.mastfrog:netty-http-test-harness:2.8.1 drop off redundant dependencies?

### DIFF
--- a/netty-http-test-harness/pom.xml
+++ b/netty-http-test-harness/pom.xml
@@ -29,10 +29,42 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>netty-http-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>giulius</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.mastfrog</groupId>
+                    <artifactId>giulius-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions> 
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_com.mastfrog:netty-http-test-harness:2.8.1_** introduced **_47_** dependencies. However, among them, **_6_** libraries (**_12%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.mastfrog:giulius-annotations:jar:2.8.0:compile
com.google.code.findbugs:jsr305:jar:3.0.2:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
javax.inject:javax.inject:jar:1:compile
com.google.errorprone:error_prone_annotations:jar:2.5.1:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_javax.inject:javax.inject:jar:1:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_com.mastfrog:netty-http-test-harness:2.8.1_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.mastfrog:netty-http-test-harness:2.8.1_**’s maven tests.

Best regards